### PR TITLE
Remove the avatar and header endpoints, use URLs instead in configuration

### DIFF
--- a/config.dist.toml
+++ b/config.dist.toml
@@ -17,8 +17,8 @@ update_freq = 5
 [actor]
 username = "blog"
 display_name = "The most perfect blog of the Web"
-avatar = "/path/to/avatar.png"
-header = "/path/to/header.jpg"
+avatar = "https://example.com/images/avatar.png"
+header = "https://example.com/images/header.jpg"
 summary = "Why make threads when you can have a blog? 👀"
 
 # A list of people you want the actor to follow, in `@username@example.com` format.

--- a/f2ap/model.py
+++ b/f2ap/model.py
@@ -1,4 +1,3 @@
-import mimetypes
 from typing import Optional
 
 from pydantic import BaseModel
@@ -112,20 +111,12 @@ class Link(Attachment):
 
 
 class File(Attachment):
-    mediaType: str
+    mediaType: Optional[str]
     url: str
 
-
-class ImageFile(File):
     @classmethod
-    def from_file(cls, path: str, url: str):
-        file_type, _ = mimetypes.guess_type(path, strict=True)
-        if file_type.split("/")[0] != "image":
-            raise TypeError(
-                f'Invalid file type for file "{path}". Check it is a valid image.'
-            )
-
-        return cls(type="Image", mediaType=file_type, url=url)
+    def make(cls, url: str, mime_type: str):
+        return cls(type="Image", mediaType=mime_type, url=url)
 
 
 class PublicKey(BaseModel):
@@ -142,8 +133,8 @@ class Actor(BaseModel):
     preferredUsername: str
     name: str
     summary: Markdown
-    icon: ImageFile
-    image: ImageFile
+    icon: File
+    image: File
     attachment: list[PropertyValue]
     following: str
     followers: str
@@ -167,8 +158,8 @@ class Actor(BaseModel):
             preferredUsername=actor.preferred_username,
             name=actor.display_name,
             summary=Markdown(actor.summary),
-            icon=ImageFile.from_file(actor.avatar, f"{actor.id}/avatar"),
-            image=ImageFile.from_file(actor.header, f"{actor.id}/header"),
+            icon=File.make(actor.avatar, f"{actor.id}/avatar"),
+            image=File.make(actor.header, f"{actor.id}/header"),
             attachment=cls.make_attachments(actor.attachments),
             following=f"{actor.id}/following",
             followers=f"{actor.id}/followers",

--- a/f2ap/webserver.py
+++ b/f2ap/webserver.py
@@ -161,34 +161,6 @@ def start_server(
 
         return respond(Actor.make(config.actor))
 
-    @app.head("/actors/{username}/avatar")
-    @app.get("/actors/{username}/avatar")
-    async def get_actor_avatar(username: str):
-        if username != config.actor.preferred_username or config.actor.avatar is None:
-            return Response(status_code=404)
-
-        file_type, _ = mimetypes.guess_type(config.actor.avatar)
-
-        if file_type not in ["image/jpeg", "image/png"]:
-            return Response(status_code=404)
-
-        with open(config.actor.avatar, "rb") as file:
-            return Response(file.read(), headers={"Content-Type": file_type})
-
-    @app.head("/actors/{username}/header")
-    @app.get("/actors/{username}/header")
-    async def get_actor_header(username: str):
-        if username != config.actor.preferred_username or config.actor.header is None:
-            return Response(status_code=404)
-
-        file_type, _ = mimetypes.guess_type(config.actor.header)
-
-        if file_type not in ["image/jpeg", "image/png"]:
-            return Response(status_code=404)
-
-        with open(config.actor.header, "rb") as file:
-            return Response(file.read(), headers={"Content-Type": file_type})
-
     @app.activitypub(
         "/actors/{username}/following",
         ignore_unset=True,


### PR DESCRIPTION
There is no need for f2ap to provide its own avatar and header system: f2ap is designed to expose an already existing website to the Fediverse, therefore users are now encouraged to upload the avatar and header directly on the website itself and give their URL in the configuration file directly.

Let's remove the complexity and just point them to URLs.